### PR TITLE
Migrate to public nested-sta-rs repo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-# Remove once nested-sta-rs goes public
-RUN sed -i 's/git = "ssh:\/\/git@github\.com\/brave\-experiments\/nested-sta-rs", branch = "main"/path = ".\/nested\-sta\-rs"/g' Cargo.toml
-
 RUN cargo install --path .
 
 RUN cargo clean


### PR DESCRIPTION
Now that the repo is publicly available, access it over https
so the default build works without write access.